### PR TITLE
DEEP-10726: Adding Package Manifest Parser interface for license scanning

### DIFF
--- a/pkg/nodejs/packagejson/parse.go
+++ b/pkg/nodejs/packagejson/parse.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/deepfactor-io/go-dep-parser/pkg/utils"
 	"github.com/deepfactor-io/go-dep-parser/pkg/types"
+	"github.com/deepfactor-io/go-dep-parser/pkg/utils"
 	"golang.org/x/xerrors"
 )
 
@@ -25,6 +25,26 @@ type Package struct {
 	OptionalDependencies map[string]string
 	DevDependencies      map[string]string
 	Workspaces           []string
+}
+
+func (p Package) PackageID() string {
+	return p.ID
+}
+
+func (p Package) DeclaredLicense() string {
+	return p.License
+}
+
+func (p Package) PackageDependencies() map[string]string {
+	return p.Dependencies
+}
+
+func (p Package) PackageDevDependencies() map[string]string {
+	return p.DevDependencies
+}
+
+func (p Package) PackageLibrary() types.Library {
+	return p.Library
 }
 
 type Parser struct{}

--- a/pkg/types/package_manifest.go
+++ b/pkg/types/package_manifest.go
@@ -1,0 +1,14 @@
+package types
+
+import "io/fs"
+
+type PackageManifest interface {
+	// Pkg ID is formed using Pkg Name and version
+	PackageID() string
+	// Declared license with the package manifest
+	DeclaredLicense() string
+}
+
+type PackageManifestParser interface {
+	ParseManifest(fsys fs.FS, path string) (PackageManifest, error)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,6 +1,8 @@
 package types
 
-import dio "github.com/deepfactor-io/go-dep-parser/pkg/io"
+import (
+	dio "github.com/deepfactor-io/go-dep-parser/pkg/io"
+)
 
 type Library struct {
 	ID                 string `json:",omitempty"`


### PR DESCRIPTION
## Adding Package Manifest Parser interface for license scanning
- Manifest Parser is needed by the recursive walker in trivy